### PR TITLE
specify resize event for removeEventListener

### DIFF
--- a/src/basilica/components.cljs
+++ b/src/basilica/components.cljs
@@ -52,7 +52,7 @@
                  (.addEventListener js/window "resize" resize-listener)
                  (om/set-state! owner :resize-listener resize-listener)))
     om/IWillUnmount
-    (will-unmount [_] (.removeEventListener js/window (om/get-state owner :resize-listener)))
+    (will-unmount [_] (.removeEventListener js/window "resize" (om/get-state owner :resize-listener)))
     om/IRender
     (render
      [_]


### PR DESCRIPTION
Trying to open a comment tree in Chrome 49 is not working because of the
error:

> Uncaught TypeError: Failed to execute 'removeEventListener' on 'EventTarget': 2 arguments required, but only 1 present.

According to MDN, "before Chrome 49, the type and listener parameters
were optional". This change explicitly passes the resize event name to
removeEventListener.
## 

I'll be honest, I have no idea what the impact of this change is or what was actually _happening_ before when only the function was specified. All I know is that I could repro the comment bug in dev and with this it works.

Very easy to get everything running by the way!
